### PR TITLE
build(docker): add base-href /woped-web/ for subpath deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npm run build -- --configuration=production
+RUN npm run build -- --configuration=production --base-href /woped-web/
 
 # Stage 2: Serve the application with Nginx
 FROM nginx:alpine


### PR DESCRIPTION
## Description

Ermöglicht das Ausliefern der App unter dem Subpath **/woped-web/** (wie auf GitHub Pages: `/woped-web/home`). Dazu wird der Production-Build mit `--base-href /woped-web/` erzeugt.

### Änderungen
- **Dockerfile**: `npm run build` um `--base-href /woped-web/` ergänzt

### Abhängigkeit / Zusammenarbeit
Die Infrastruktur (Apache + Nginx im Container) muss den Pfad `/woped-web` an diesen Container weiterleiten. Dafür ist ein PR im Repo **infrastructure** offen: [feature/woped-web-subpath-deployment](https://github.com/woped/infrastructure/pull/new/feature/woped-web-subpath-deployment).

Nach Merge beider PRs und neuem Image-Deploy ist die App unter `https://woped.dhbw-karlsruhe.de/woped-web/home` erreichbar.

## Checklist
- [x] Build mit `--base-href /woped-web/` getestet (Assets/Router unter Subpath)
- [x] PR adheres to the contributing guidelines
- [ ] Reviewers zugewiesen (bitte im UI ergänzen)

Made with [Cursor](https://cursor.com)